### PR TITLE
fix(solana): resolve token program from mint instead of hardcoding cl…

### DIFF
--- a/src/solana/examples/withdrawal/README.md
+++ b/src/solana/examples/withdrawal/README.md
@@ -74,7 +74,14 @@ The rest of your `submitSignatures` flow (instruction name and accounts like `co
 For the **withdrawCollateralAsset** instruction, the V2 program requires two extra accounts. Add them to the `.accounts(...)` object:
 
 - **rentReceiver** — Set the account that will receive the lamports back when the signatures account is closed. It must to be the same account set as rent payer in the `submitSignatures` transaction.
-- **tokenProgram** — Set to the SPL Token program: `TOKEN_PROGRAM_ID` (from `@solana/spl-token`).
+- **tokenProgram** — Set to the token program that **owns the mint**, not a hardcoded value. For a classic SPL mint this is `TOKEN_PROGRAM_ID`; for a Token-2022 mint it must be `TOKEN_2022_PROGRAM_ID` (both from `@solana/spl-token`). Hardcoding `TOKEN_PROGRAM_ID` silently derives the wrong associated token accounts for Token-2022 mints. Resolve it from the mint — its account `owner` *is* its token program — and use the same value when deriving `collateralTokenAccount` / `receiverTokenAccount`:
+
+  ```ts
+  // The mint account is owned by exactly its token program.
+  const mintInfo = await connection.getAccountInfo(mintAddress);
+  const tokenProgram = mintInfo!.owner; // TOKEN_PROGRAM_ID or TOKEN_2022_PROGRAM_ID
+  ```
+
 
 So the accounts for `withdrawCollateralAsset` change from:
 
@@ -104,6 +111,6 @@ to:
   coordinator: collateralAccount.coordinator,
   collateral: collateral,
   collateralAdminSignatures: collateralSignatureAddress,
-  tokenProgram: TOKEN_PROGRAM_ID,
+  tokenProgram, // resolved from the mint owner (see note above), not hardcoded
 })
 ```

--- a/src/solana/examples/withdrawal/multisig_program_v2_00/index.ts
+++ b/src/solana/examples/withdrawal/multisig_program_v2_00/index.ts
@@ -454,12 +454,13 @@ class Coordinator {
 }
 
 
+
 /**
- * Get or create the associated token account for the recipient to receive 
+ * Get or create the associated token account for the recipient to receive
  * the withdrawn tokens
- * 
+ *
  * @param program - The program instance
- * @param sender - The sender of the transaction  
+ * @param sender - The sender of the transaction
  * @param recipientAddress - The address of the recipient
  * @param mintAddress - The mint address of the token being withdrawn
  * @returns The associated token account address for the recipient

--- a/src/solana/examples/withdrawal/multisig_program_v2_01/index.ts
+++ b/src/solana/examples/withdrawal/multisig_program_v2_01/index.ts
@@ -123,6 +123,7 @@ import {
   getOrCreateAssociatedTokenAccount,
   getAssociatedTokenAddress,
   TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
   Account
 } from "@solana/spl-token";
 import { Ed25519ExtendedProgram, IdlV2_01, MainV2_01 } from "@rain/program";
@@ -469,6 +470,7 @@ async function getDestinationTokenAccount(
   sender: Keypair,
   recipientAddress: PublicKey,
   mintAddress: PublicKey,
+  tokenProgramId: PublicKey,
 ): Promise<Account> {
   return await getOrCreateAssociatedTokenAccount(
     program.provider.connection,
@@ -478,8 +480,28 @@ async function getDestinationTokenAccount(
     false,
     'confirmed',
     { commitment: 'confirmed' },
-    TOKEN_PROGRAM_ID
+    tokenProgramId
   );
+}
+
+/**
+ * Resolve the SPL Token program that owns a mint (classic SPL vs Token-2022).
+ *
+ * @param connection - An RPC connection
+ * @param mintAddress - The token mint to resolve the program for
+ * @returns TOKEN_PROGRAM_ID or TOKEN_2022_PROGRAM_ID
+ */
+async function resolveMintTokenProgram(connection: Connection, mintAddress: PublicKey): Promise<PublicKey> {
+  const mintInfo = await connection.getAccountInfo(mintAddress);
+  if (!mintInfo) {
+    throw new Error(`Mint account ${mintAddress.toBase58()} not found`);
+  }
+  if (!mintInfo.owner.equals(TOKEN_PROGRAM_ID) && !mintInfo.owner.equals(TOKEN_2022_PROGRAM_ID)) {
+    throw new Error(
+      `Mint ${mintAddress.toBase58()} is not owned by a known SPL Token program (owner: ${mintInfo.owner.toBase58()})`
+    );
+  }
+  return mintInfo.owner;
 }
 
 /**
@@ -489,11 +511,12 @@ async function getDestinationTokenAccount(
  * @param mintAddress - The mint address of the token being withdrawn
  * @returns The associated token account address for the collateral
  */
-async function getSourceTokenAccount(depositAddress: PublicKey, mintAddress: PublicKey) {
+async function getSourceTokenAccount(depositAddress: PublicKey, mintAddress: PublicKey, tokenProgramId: PublicKey) {
   return await getAssociatedTokenAddress(
     mintAddress,
     depositAddress,
-    true
+    true,
+    tokenProgramId
   );
 }
 
@@ -662,17 +685,22 @@ async function executeWithdrawal(
 
   const collateralAccount = await program.account.collateralV2.fetch(collateral)
 
+  // Resolve the mint's token program (classic SPL vs Token-2022) so the derived accounts and the
+  // instruction are built under the correct program.
+  const tokenProgramId = await resolveMintTokenProgram(program.provider.connection, mintAddress)
+
   // Get the source token account for the collateral to withdraw from
-  const collateralTokenAccount = await getSourceTokenAccount(depositAddress, mintAddress)
+  const collateralTokenAccount = await getSourceTokenAccount(depositAddress, mintAddress, tokenProgramId)
   console.log("Source token account", collateralTokenAccount.toBase58())
 
-  // Get or create the associated token account for the recipient to receive 
+  // Get or create the associated token account for the recipient to receive
   // the withdrawn tokens
   const destinationTokenAccount = await getDestinationTokenAccount(
     program,
     sender,
     recipientAddress,
     mintAddress,
+    tokenProgramId,
   );
   console.log("Destination token account", destinationTokenAccount.address.toBase58())
 
@@ -724,7 +752,7 @@ async function executeWithdrawal(
           coordinator: collateralAccount.coordinator,
           collateral: collateral,
           collateralAdminSignatures: collateralSignatureAddress,
-          tokenProgram: TOKEN_PROGRAM_ID
+          tokenProgram: tokenProgramId
         })
         .instruction()
     ),

--- a/src/solana/examples/withdrawal/single_signer_program_v2_02/index.ts
+++ b/src/solana/examples/withdrawal/single_signer_program_v2_02/index.ts
@@ -81,6 +81,7 @@ import {
   getOrCreateAssociatedTokenAccount,
   getAssociatedTokenAddress,
   TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
   Account
 } from "@solana/spl-token";
 
@@ -299,6 +300,7 @@ async function getDestinationTokenAccount(
   owner: Keypair,
   recipientAddress: PublicKey,
   mintAddress: PublicKey,
+  tokenProgramId: PublicKey,
 ): Promise<Account> {
   return await getOrCreateAssociatedTokenAccount(
     program.provider.connection,
@@ -308,8 +310,28 @@ async function getDestinationTokenAccount(
     false,
     'confirmed',
     { commitment: 'confirmed' },
-    TOKEN_PROGRAM_ID
+    tokenProgramId
   );
+}
+
+/**
+ * Resolve the SPL Token program that owns a mint (classic SPL vs Token-2022).
+ *
+ * @param connection - An RPC connection
+ * @param mintAddress - The token mint to resolve the program for
+ * @returns TOKEN_PROGRAM_ID or TOKEN_2022_PROGRAM_ID
+ */
+async function resolveMintTokenProgram(connection: Connection, mintAddress: PublicKey): Promise<PublicKey> {
+  const mintInfo = await connection.getAccountInfo(mintAddress);
+  if (!mintInfo) {
+    throw new Error(`Mint account ${mintAddress.toBase58()} not found`);
+  }
+  if (!mintInfo.owner.equals(TOKEN_PROGRAM_ID) && !mintInfo.owner.equals(TOKEN_2022_PROGRAM_ID)) {
+    throw new Error(
+      `Mint ${mintAddress.toBase58()} is not owned by a known SPL Token program (owner: ${mintInfo.owner.toBase58()})`
+    );
+  }
+  return mintInfo.owner;
 }
 
 /**
@@ -319,11 +341,12 @@ async function getDestinationTokenAccount(
  * @param mintAddress - The mint address of the token being withdrawn
  * @returns The associated token account address for the collateral
  */
-async function getSourceTokenAccount(depositAddress: PublicKey, mintAddress: PublicKey) {
+async function getSourceTokenAccount(depositAddress: PublicKey, mintAddress: PublicKey, tokenProgramId: PublicKey) {
   return await getAssociatedTokenAddress(
     mintAddress,
     depositAddress,
-    true
+    true,
+    tokenProgramId
   );
 }
 
@@ -409,10 +432,15 @@ async function executeWithdrawal(
   // Get token accounts (null for SOL withdrawals)
   let collateralTokenAccount: PublicKey | null = null;
   let destinationTokenAccount: Account | null = null;
+  // Default to classic SPL; resolved from the mint for SPL withdrawals below so Token-2022 mints
+  // derive their accounts (and build the instruction) under the correct program.
+  let tokenProgramId = TOKEN_PROGRAM_ID;
 
   if (!mintAddress.equals(PublicKey.default)) {
-    // SPL token withdrawal
-    collateralTokenAccount = await getSourceTokenAccount(depositAddress, mintAddress)
+    // SPL token withdrawal — resolve the mint's token program (classic SPL vs Token-2022)
+    tokenProgramId = await resolveMintTokenProgram(program.provider.connection, mintAddress)
+
+    collateralTokenAccount = await getSourceTokenAccount(depositAddress, mintAddress, tokenProgramId)
     console.log("Source token account", collateralTokenAccount.toBase58())
 
     destinationTokenAccount = await getDestinationTokenAccount(
@@ -420,6 +448,7 @@ async function executeWithdrawal(
       owner,
       recipientAddress,
       mintAddress,
+      tokenProgramId,
     );
     console.log("Destination token account", destinationTokenAccount.address.toBase58())
   } else {
@@ -465,7 +494,7 @@ async function executeWithdrawal(
           asset: mintAddress.equals(PublicKey.default) ? null : mintAddress,
           collateralTokenAccount: collateralTokenAccount,
           destinationTokenAccount: destinationTokenAccount ? destinationTokenAccount.address : null,
-          tokenProgram: TOKEN_PROGRAM_ID,
+          tokenProgram: tokenProgramId,
         })
         .instruction()
     ),

--- a/src/solana/examples/withdrawal/single_signer_squad_program_v2_02/README.md
+++ b/src/solana/examples/withdrawal/single_signer_squad_program_v2_02/README.md
@@ -245,6 +245,14 @@ This example demonstrates how to use [Squads Multisig v4](https://docs.squads.so
 3. Create the signature verification and the withdraw collateral asset instructions
 
 ```typescript
+  // Resolve the token program from the mint — a mint account is owned by exactly its token
+  // program, so this yields TOKEN_PROGRAM_ID for classic SPL mints and TOKEN_2022_PROGRAM_ID for
+  // Token-2022 mints. Use the same value when deriving collateralTokenAccount /
+  // destinationTokenAccount; hardcoding TOKEN_PROGRAM_ID silently derives wrong accounts for
+  // Token-2022 mints.
+  const mintInfo = await connection.getAccountInfo(mintAddress);
+  const tokenProgramId = mintInfo!.owner;
+
   const withdrawalInstruction = await program.methods.withdrawSingleSignerCollateralAsset(withdrawRequest)                        
         .accounts({                                                                                
           owner: vaultPda,                                                                   
@@ -254,7 +262,7 @@ This example demonstrates how to use [Squads Multisig v4](https://docs.squads.so
           asset: mintAddress,                        
           collateralTokenAccount: collateralTokenAccount,                                           
           destinationTokenAccount,
-          tokenProgram: TOKEN_PROGRAM_ID,                                                           
+          tokenProgram: tokenProgramId, // resolved from the mint owner (TOKEN_PROGRAM_ID or TOKEN_2022_PROGRAM_ID), not hardcoded
         })
 
   const signatureVerificationInstruction = Ed25519ExtendedProgram.createSignatureVerificationInstruction([

--- a/src/solana/examples/withdrawal/single_signer_squad_program_v2_02/index.ts
+++ b/src/solana/examples/withdrawal/single_signer_squad_program_v2_02/index.ts
@@ -94,6 +94,7 @@ import {
   getOrCreateAssociatedTokenAccount,
   getAssociatedTokenAddress,
   TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
   Account
 } from "@solana/spl-token";
 
@@ -269,6 +270,7 @@ async function getDestinationTokenAccount(
   payer: Keypair,
   recipientAddress: PublicKey,
   mintAddress: PublicKey,
+  tokenProgramId: PublicKey,
 ): Promise<Account> {
   return await getOrCreateAssociatedTokenAccount(
     connection,
@@ -278,8 +280,28 @@ async function getDestinationTokenAccount(
     false,
     'confirmed',
     { commitment: 'confirmed' },
-    TOKEN_PROGRAM_ID
+    tokenProgramId
   );
+}
+
+/**
+ * Resolve the SPL Token program that owns a mint (classic SPL vs Token-2022).
+ *
+ * @param connection - An RPC connection
+ * @param mintAddress - The token mint to resolve the program for
+ * @returns TOKEN_PROGRAM_ID or TOKEN_2022_PROGRAM_ID
+ */
+async function resolveMintTokenProgram(connection: Connection, mintAddress: PublicKey): Promise<PublicKey> {
+  const mintInfo = await connection.getAccountInfo(mintAddress);
+  if (!mintInfo) {
+    throw new Error(`Mint account ${mintAddress.toBase58()} not found`);
+  }
+  if (!mintInfo.owner.equals(TOKEN_PROGRAM_ID) && !mintInfo.owner.equals(TOKEN_2022_PROGRAM_ID)) {
+    throw new Error(
+      `Mint ${mintAddress.toBase58()} is not owned by a known SPL Token program (owner: ${mintInfo.owner.toBase58()})`
+    );
+  }
+  return mintInfo.owner;
 }
 
 /**
@@ -289,11 +311,12 @@ async function getDestinationTokenAccount(
  * @param mintAddress - The mint address of the token being withdrawn
  * @returns The associated token account address for the collateral
  */
-async function getSourceTokenAccount(depositAddress: PublicKey, mintAddress: PublicKey) {
+async function getSourceTokenAccount(depositAddress: PublicKey, mintAddress: PublicKey, tokenProgramId: PublicKey) {
   return await getAssociatedTokenAddress(
     mintAddress,
     depositAddress,
-    true
+    true,
+    tokenProgramId
   );
 }
 
@@ -357,10 +380,15 @@ async function buildWithdrawalInstructions(
   // Get token accounts (null for SOL withdrawals)
   let collateralTokenAccount: PublicKey | null = null;
   let destinationTokenAccount: Account | null = null;
+  // Default to classic SPL; resolved from the mint for SPL withdrawals below so Token-2022 mints
+  // derive their accounts (and build the instruction) under the correct program.
+  let tokenProgramId = TOKEN_PROGRAM_ID;
 
   if (!mintAddress.equals(PublicKey.default)) {
-    // SPL token withdrawal
-    collateralTokenAccount = await getSourceTokenAccount(depositAddress, mintAddress)
+    // SPL token withdrawal — resolve the mint's token program (classic SPL vs Token-2022)
+    tokenProgramId = await resolveMintTokenProgram(program.provider.connection, mintAddress)
+
+    collateralTokenAccount = await getSourceTokenAccount(depositAddress, mintAddress, tokenProgramId)
     console.log("Source token account", collateralTokenAccount.toBase58())
 
     destinationTokenAccount = await getDestinationTokenAccount(
@@ -368,6 +396,7 @@ async function buildWithdrawalInstructions(
       payer,
       recipientAddress,
       mintAddress,
+      tokenProgramId,
     );
     console.log("Destination token account", destinationTokenAccount.address.toBase58())
   } else {
@@ -410,7 +439,7 @@ async function buildWithdrawalInstructions(
       asset: mintAddress.equals(PublicKey.default) ? null : mintAddress,
       collateralTokenAccount: collateralTokenAccount,
       destinationTokenAccount: destinationTokenAccount ? destinationTokenAccount.address : null,
-      tokenProgram: TOKEN_PROGRAM_ID,
+      tokenProgram: tokenProgramId,
     })
     .instruction();
 


### PR DESCRIPTION

The withdrawal examples hardcoded TOKEN_PROGRAM_ID when deriving the collateral/destination ATAs and when setting the instruction's tokenProgram account. For a Token-2022 mint this silently derives the wrong accounts and builds the transfer against the wrong program.

For v2.01/v2.02 examples (single_signer_v2_02, single_signer_squad_v2_02, multisig_v2_01) the on-chain withdraw instruction CPIs against the client-supplied tokenProgram, so resolve it from the mint's on-chain owner (a mint is owned by exactly its token program) and thread it through ATA derivation and the instruction.
